### PR TITLE
Fix command line argument processing. 'publicPath' was being set to Nan in all cases.

### DIFF
--- a/lib/simple-server.js
+++ b/lib/simple-server.js
@@ -5,25 +5,25 @@
 	var pathUtil = require('path')
 
 	// Arguments
-	var port, publicPath, arg;
+	var port, possiblePort, publicPath, arg;
 	arg = process.argv[2];
 	if ( arg ) {
-		port = parseInt(arg, 10);
-		if ( isNaN(port) ) {
+		possiblePort = parseInt(arg, 10);
+		if ( isNaN(possiblePort) ) {
 			publicPath = arg;
 		}
 		else {
-			port = port;
+			port = possiblePort;
 		}
 	}
 	arg = process.argv[3];
 	if ( arg ) {
-		port = parseInt(arg, 10);
-		if ( isNaN(port) ) {
+		possiblePort = parseInt(arg, 10);
+		if ( isNaN(possiblePort) ) {
 			publicPath = arg;
 		}
 		else {
-			port = port;
+			port = possiblePort;
 		}
 	}
 	port = port || 3000;


### PR DESCRIPTION
It's not possible to specify a directory other than the default '.' because publicPath is always set to NaN.
